### PR TITLE
Update index.lua

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -716,7 +716,7 @@
 			if (session:ready()) then
 				--set the variables
 					session:execute("set", "hangup_after_bridge=true");
-					session:execute("set", "continue_on_fail=true");
+					-- session:execute("set", "continue_on_fail=true");
 
 				-- support conf-xfer feature
 				-- do


### PR DESCRIPTION
When bridge application ends with "originate_disposition: ALLOTTED_TIMEOUT" for example, the "missed call" feature doesn't work for ring group because of hangup hook isn't called. Should we just avoid using this channel variable or add additional processing at the end? Like for timeout action?